### PR TITLE
Add basic Plinko game with configurable settings

### DIFF
--- a/src/app/plinko/page.tsx
+++ b/src/app/plinko/page.tsx
@@ -1,0 +1,12 @@
+"use client"
+
+import { Plinko } from "@/components/game/Plinko"
+
+export default function PlinkoPage() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Plinko</h1>
+      <Plinko />
+    </div>
+  )
+}

--- a/src/components/game/Plinko.tsx
+++ b/src/components/game/Plinko.tsx
@@ -87,15 +87,14 @@ export function Plinko({ initialConfig }: PlinkoProps) {
   const preserveBallsRef = useRef(false)
   const restartRef = useRef(false)
 
-  const stopGame = (preserve: boolean) => {
+  const stopGame = (preserve: boolean): void => {
     preserveBallsRef.current = preserve
     setStarted(false)
   }
 
-  const startGame = (resetBoard: boolean = true) => {
+  const startGame = (resetBoard: boolean = true): void => {
     preserveBallsRef.current = false
     if (resetBoard) {
-      setConfig(prev => ({ ...prev }))
       setBoardKey(k => k + 1)
     }
     setStarted(true)
@@ -104,7 +103,7 @@ export function Plinko({ initialConfig }: PlinkoProps) {
   const updateConfig = <K extends keyof PlinkoConfig>(
     key: K,
     value: PlinkoConfig[K]
-  ) => {
+  ): void => {
     setConfig(prev => ({ ...prev, [key]: value }))
     setBoardKey(k => k + 1)
     if (started) {
@@ -238,7 +237,7 @@ export function Plinko({ initialConfig }: PlinkoProps) {
         render.canvas.parentNode.removeChild(render.canvas)
       }
     }
-  }, [config, engine, runner])
+  }, [config, boardKey, engine, runner])
 
   useEffect(() => {
     if (!started) {

--- a/src/components/game/Plinko.tsx
+++ b/src/components/game/Plinko.tsx
@@ -16,7 +16,8 @@ export interface PlinkoConfig {
   wallThickness: number
   bucketCount: number
   winCount: number
-  autoStart: boolean
+  width: number
+  height: number
 }
 
 export interface PlinkoProps {
@@ -35,7 +36,8 @@ const defaultConfig: PlinkoConfig = {
   wallThickness: 10,
   bucketCount: 6,
   winCount: 3,
-  autoStart: false
+  width: 600,
+  height: 500
 }
 
 export function Plinko({ initialConfig }: PlinkoProps) {
@@ -46,111 +48,122 @@ export function Plinko({ initialConfig }: PlinkoProps) {
   const [config, setConfig] = useState<PlinkoConfig>(initialConfig ?? defaultConfig)
   const [showConfig, setShowConfig] = useState(false)
   
-  const updateConfig = (key: keyof PlinkoConfig, value: number | boolean) => {
+  const updateConfig = (key: keyof PlinkoConfig, value: number) => {
     setConfig(prev => ({ ...prev, [key]: value }))
   }
 
-  useEffect(() => {
-    if (config.autoStart && !started) {
-      setStarted(true)
-    }
-  }, [config.autoStart, started])
 
   useEffect(() => {
-    if (started && canvasRef.current != null) {
-      const width = canvasRef.current.clientWidth
-      const height = 500
-      const render = Render.create({
-        element: canvasRef.current,
-        engine,
-        options: { width, height, wireframes: false, background: "#f8fafc" }
-      })
+    if (canvasRef.current == null) return
 
-      const walls = [
-        Bodies.rectangle(width / 2, -25, width, 50, { isStatic: true }),
-        Bodies.rectangle(width / 2, height + 25, width, 50, { isStatic: true }),
-        Bodies.rectangle(-25, height / 2, 50, height, { isStatic: true }),
-        Bodies.rectangle(width + 25, height / 2, 50, height, { isStatic: true })
-      ]
+    const { width, height } = config
+    const render = Render.create({
+      element: canvasRef.current,
+      engine,
+      options: { width, height, wireframes: false, background: "#f8fafc" }
+    })
 
-      Composite.add(engine.world, walls)
+    const walls = [
+      Bodies.rectangle(width / 2, -25, width, 50, { isStatic: true }),
+      Bodies.rectangle(width / 2, height + 25, width, 50, { isStatic: true }),
+      Bodies.rectangle(-25, height / 2, 50, height, { isStatic: true }),
+      Bodies.rectangle(width + 25, height / 2, 50, height, { isStatic: true })
+    ]
 
-      // pins
-      const xSpacing = width / config.pinColumns
-      const ySpacing = (height - 100) / config.pinRows
-      const pins: Matter.Body[] = []
-      for (let row = 0; row < config.pinRows; row++) {
-        for (let col = 0; col < config.pinColumns; col++) {
-          const x = xSpacing / 2 + col * xSpacing + (row % 2 === 0 ? xSpacing / 2 : 0)
-          const y = 50 + row * ySpacing
-          pins.push(Bodies.circle(x, y, config.pinRadius, { isStatic: true }))
-        }
+    Composite.add(engine.world, walls)
+
+    const xSpacing = width / config.pinColumns
+    const ySpacing = (height - 100) / config.pinRows
+    const pins: Matter.Body[] = []
+    for (let row = 0; row < config.pinRows; row++) {
+      for (let col = 0; col < config.pinColumns; col++) {
+        const x = xSpacing / 2 + col * xSpacing + (row % 2 === 0 ? xSpacing / 2 : 0)
+        const y = 50 + row * ySpacing
+        pins.push(Bodies.circle(x, y, config.pinRadius, { isStatic: true }))
       }
-      Composite.add(engine.world, pins)
+    }
+    Composite.add(engine.world, pins)
 
       // buckets
-      const bucketWidth = width / config.bucketCount
-      for (let i = 0; i <= config.bucketCount; i++) {
-        const x = i * bucketWidth
-        Composite.add(engine.world, [
-          Bodies.rectangle(x, height - 50, config.wallThickness, 100, { isStatic: true })
-        ])
-      }
+    const bucketWidth = width / config.bucketCount
+    for (let i = 0; i <= config.bucketCount; i++) {
+      const x = i * bucketWidth
+      Composite.add(engine.world, [
+        Bodies.rectangle(x, height - 50, config.wallThickness, 100, { isStatic: true })
+      ])
+    }
 
-      Render.run(render)
-      Runner.run(runner, engine)
+    Render.run(render)
+    Runner.run(runner, engine)
 
-      let dropped = 0
-      const balls: Matter.Body[] = []
-      const bucketCounts = new Array(config.bucketCount).fill(0)
-      const dropInterval = setInterval(() => {
-        if (dropped >= config.ballCount) {
-          clearInterval(dropInterval)
-          return
-        }
-        const ball = Bodies.circle(width / 2, 0, config.ballRadius, {
-          restitution: config.ballRestitution,
-          friction: config.ballFriction
-        })
-        balls.push(ball)
-        Composite.add(engine.world, ball)
-        dropped += 1
-      }, 500)
-
-      const afterUpdate = () => {
-        balls.forEach((ball, index) => {
-          if (ball.position.y > height - 60 && Math.abs(ball.velocity.y) < 1) {
-            const bucket = Math.floor(ball.position.x / bucketWidth)
-            if (bucket >= 0 && bucket < bucketCounts.length) {
-              bucketCounts[bucket] += 1
-              Composite.remove(engine.world, ball)
-              balls.splice(index, 1)
-              if (bucketCounts[bucket] >= config.winCount) {
-                setStarted(false)
-                clearInterval(dropInterval)
-              }
-            }
-          }
-        })
-      }
-      Events.on(engine, "afterUpdate", afterUpdate)
-
-      return () => {
-        clearInterval(dropInterval)
-        Events.off(engine, "afterUpdate", afterUpdate)
-        Render.stop(render)
-        Runner.stop(runner)
-        Composite.clear(engine.world, false)
-        if (render.canvas.parentNode != null) {
-          render.canvas.parentNode.removeChild(render.canvas)
-        }
+    return () => {
+      Render.stop(render)
+      Runner.stop(runner)
+      Composite.clear(engine.world, false)
+      if (render.canvas.parentNode != null) {
+        render.canvas.parentNode.removeChild(render.canvas)
       }
     }
-  }, [started, config, engine, runner])
+  }, [config, engine, runner])
+
+  useEffect(() => {
+    if (!started) {
+      return
+    }
+
+    const { width, height } = config
+    const bucketWidth = width / config.bucketCount
+    const balls: Matter.Body[] = []
+    const bucketCounts = new Array(config.bucketCount).fill(0)
+    let dropped = 0
+
+    const dropInterval = setInterval(() => {
+      if (dropped >= config.ballCount) {
+        clearInterval(dropInterval)
+        return
+      }
+      const ball = Bodies.circle(width / 2, 0, config.ballRadius, {
+        restitution: config.ballRestitution,
+        friction: config.ballFriction
+      })
+      balls.push(ball)
+      Composite.add(engine.world, ball)
+      dropped += 1
+    }, 500)
+
+    const afterUpdate = () => {
+      balls.forEach((ball, index) => {
+        if (ball.position.y > height - 60 && Math.abs(ball.velocity.y) < 1) {
+          const bucket = Math.floor(ball.position.x / bucketWidth)
+          if (bucket >= 0 && bucket < bucketCounts.length) {
+            bucketCounts[bucket] += 1
+            Composite.remove(engine.world, ball)
+            balls.splice(index, 1)
+            if (bucketCounts[bucket] >= config.winCount) {
+              setStarted(false)
+              clearInterval(dropInterval)
+            }
+          }
+        }
+      })
+    }
+
+    Events.on(engine, "afterUpdate", afterUpdate)
+
+    return () => {
+      clearInterval(dropInterval)
+      Events.off(engine, "afterUpdate", afterUpdate)
+      balls.forEach(ball => Composite.remove(engine.world, ball))
+    }
+  }, [started, config, engine])
 
   return (
     <div className="space-y-2">
-      <div className="w-full border" ref={canvasRef} />
+      <div
+        className="border"
+        ref={canvasRef}
+        style={{ width: config.width, height: config.height }}
+      />
       <div className="flex gap-2">
         <Button onClick={() => setStarted(true)}>Start</Button>
         <Button variant="outline" onClick={() => setShowConfig(v => !v)}>
@@ -178,6 +191,39 @@ export function Plinko({ initialConfig }: PlinkoProps) {
             </div>
           </fieldset>
           <fieldset className="space-y-2">
+            <legend className="font-semibold">Board</legend>
+            <div className="grid grid-cols-2 gap-2 items-center">
+              <RangeSlider
+                value={config.width}
+                onValueChange={v => updateConfig('width', v)}
+                min={300}
+                max={1000}
+              />
+              <Input
+                type="number"
+                value={config.width}
+                onChange={e => updateConfig('width', Number(e.target.value))}
+                min={300}
+                max={1000}
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-2 items-center">
+              <RangeSlider
+                value={config.height}
+                onValueChange={v => updateConfig('height', v)}
+                min={300}
+                max={800}
+              />
+              <Input
+                type="number"
+                value={config.height}
+                onChange={e => updateConfig('height', Number(e.target.value))}
+                min={300}
+                max={800}
+              />
+            </div>
+          </fieldset>
+          <fieldset className="space-y-2">
             <legend className="font-semibold">Win</legend>
             <div className="grid grid-cols-2 gap-2 items-center">
               <RangeSlider
@@ -193,14 +239,6 @@ export function Plinko({ initialConfig }: PlinkoProps) {
                 min={1}
                 max={config.ballCount}
               />
-            </div>
-            <div className="flex items-center gap-2">
-              <input
-                type="checkbox"
-                checked={config.autoStart}
-                onChange={e => updateConfig('autoStart', e.target.checked)}
-              />
-              <span>Auto Start</span>
             </div>
           </fieldset>
         </div>

--- a/src/components/game/Plinko.tsx
+++ b/src/components/game/Plinko.tsx
@@ -104,14 +104,12 @@ export function Plinko({ initialConfig }: PlinkoProps) {
     key: K,
     value: PlinkoConfig[K]
   ): void => {
-    setConfig(prev => ({ ...prev, [key]: value }))
-    setBoardKey(k => k + 1)
-    if (started) {
-      restartRef.current = true
-      stopGame(false)
-    } else if (preserveBallsRef.current) {
+    if (started || preserveBallsRef.current) {
+      if (started) restartRef.current = true
       stopGame(false)
     }
+    setConfig(prev => ({ ...prev, [key]: value }))
+    setBoardKey(k => k + 1)
   }
 
   useEffect(() => {

--- a/src/components/game/Plinko.tsx
+++ b/src/components/game/Plinko.tsx
@@ -107,6 +107,8 @@ export function Plinko({ initialConfig }: PlinkoProps) {
     if (started) {
       restartRef.current = true
       stopGame(false)
+    } else if (preserveBallsRef.current) {
+      stopGame(false)
     }
   }
 

--- a/src/components/game/Plinko.tsx
+++ b/src/components/game/Plinko.tsx
@@ -1,20 +1,33 @@
 "use client"
 
 import React, { useRef, useState, useEffect } from "react"
-import Matter, { Engine, Render, Runner, Bodies, Composite, Events } from "matter-js"
+import Matter, {
+  Engine,
+  Render,
+  Runner,
+  Bodies,
+  Composite,
+  Events
+} from "matter-js"
 import { Button } from "@/components/ui/button"
-import { Input, RangeSlider } from "@/components/ui"
+import { Input, RangeSlider, Select } from "@/components/ui"
 
 export interface PlinkoConfig {
   ballCount: number
   ballRadius: number
   ballRestitution: number
   ballFriction: number
+  ballShape: "ball" | "square" | "triangle"
+  dropLocation: "random" | "zigzag" | "center"
   pinRadius: number
   pinRows: number
   pinColumns: number
+  pinRestitution: number
+  pinFriction: number
+  pinShape: "ball" | "square" | "triangle"
   wallThickness: number
   bucketCount: number
+  bucketDistribution: "even" | "middle" | "edge"
   winCount: number
   width: number
   height: number
@@ -30,11 +43,17 @@ const defaultConfig: PlinkoConfig = {
   ballRadius: 8,
   ballRestitution: 0.9,
   ballFriction: 0.005,
+  ballShape: "ball",
+  dropLocation: "center",
   pinRadius: 3,
   pinRows: 10,
   pinColumns: 8,
+  pinRestitution: 0.5,
+  pinFriction: 0.1,
+  pinShape: "ball",
   wallThickness: 10,
   bucketCount: 6,
+  bucketDistribution: "even",
   winCount: 3,
   width: 600,
   height: 500
@@ -47,9 +66,55 @@ export function Plinko({ initialConfig }: PlinkoProps) {
   const [started, setStarted] = useState(false)
   const [config, setConfig] = useState<PlinkoConfig>(initialConfig ?? defaultConfig)
   const [showConfig, setShowConfig] = useState(false)
+  const bucketBoundsRef = useRef<number[]>([])
   
-  const updateConfig = (key: keyof PlinkoConfig, value: number) => {
+  const updateConfig = <K extends keyof PlinkoConfig>(
+    key: K,
+    value: PlinkoConfig[K]
+  ) => {
     setConfig(prev => ({ ...prev, [key]: value }))
+  }
+
+  const makeShape = (
+    type: "ball" | "square" | "triangle",
+    x: number,
+    y: number,
+    radius: number,
+    options: Matter.IBodyDefinition
+  ): Matter.Body => {
+    switch (type) {
+      case "square":
+        return Bodies.rectangle(x, y, radius * 2, radius * 2, options)
+      case "triangle":
+        return Bodies.polygon(x, y, 3, radius, options)
+      case "ball":
+      default:
+        return Bodies.circle(x, y, radius, options)
+    }
+  }
+
+  const bucketBounds = (
+    count: number,
+    totalWidth: number,
+    distribution: "even" | "middle" | "edge"
+  ): number[] => {
+    if (distribution === "even") {
+      return Array.from({ length: count + 1 }, (_, i) => (i * totalWidth) / count)
+    }
+    const weights: number[] = []
+    for (let i = 0; i < count; i++) {
+      const t = i / (count - 1)
+      const base = 1 + Math.cos((t - 0.5) * Math.PI)
+      weights.push(distribution === "middle" ? base : 2 - base)
+    }
+    const sum = weights.reduce((a, b) => a + b, 0)
+    const bounds: number[] = [0]
+    let pos = 0
+    for (let i = 0; i < count; i++) {
+      pos += (totalWidth * weights[i]) / sum
+      bounds.push(pos)
+    }
+    return bounds
   }
 
 
@@ -79,15 +144,20 @@ export function Plinko({ initialConfig }: PlinkoProps) {
       for (let col = 0; col < config.pinColumns; col++) {
         const x = xSpacing / 2 + col * xSpacing + (row % 2 === 0 ? xSpacing / 2 : 0)
         const y = 50 + row * ySpacing
-        pins.push(Bodies.circle(x, y, config.pinRadius, { isStatic: true }))
+        pins.push(
+          makeShape(config.pinShape, x, y, config.pinRadius, {
+            isStatic: true,
+            restitution: config.pinRestitution,
+            friction: config.pinFriction
+          })
+        )
       }
     }
     Composite.add(engine.world, pins)
 
-      // buckets
-    const bucketWidth = width / config.bucketCount
-    for (let i = 0; i <= config.bucketCount; i++) {
-      const x = i * bucketWidth
+    const bounds = bucketBounds(config.bucketCount, width, config.bucketDistribution)
+    bucketBoundsRef.current = bounds
+    for (const x of bounds) {
       Composite.add(engine.world, [
         Bodies.rectangle(x, height - 50, config.wallThickness, 100, { isStatic: true })
       ])
@@ -112,17 +182,29 @@ export function Plinko({ initialConfig }: PlinkoProps) {
     }
 
     const { width, height } = config
-    const bucketWidth = width / config.bucketCount
+    const bounds = bucketBoundsRef.current
     const balls: Matter.Body[] = []
     const bucketCounts = new Array(config.bucketCount).fill(0)
     let dropped = 0
+    const zig = { x: Math.random() * width, dir: 1 }
 
     const dropInterval = setInterval(() => {
       if (dropped >= config.ballCount) {
         clearInterval(dropInterval)
         return
       }
-      const ball = Bodies.circle(width / 2, 0, config.ballRadius, {
+      let x = width / 2
+      if (config.dropLocation === "random") {
+        x = Math.random() * width
+      } else if (config.dropLocation === "zigzag") {
+        x = zig.x
+        zig.x += (width / config.pinColumns) * zig.dir
+        if (zig.x < config.ballRadius || zig.x > width - config.ballRadius) {
+          zig.dir *= -1
+          zig.x = Math.max(config.ballRadius, Math.min(width - config.ballRadius, zig.x))
+        }
+      }
+      const ball = makeShape(config.ballShape, x, 0, config.ballRadius, {
         restitution: config.ballRestitution,
         friction: config.ballFriction
       })
@@ -134,7 +216,13 @@ export function Plinko({ initialConfig }: PlinkoProps) {
     const afterUpdate = () => {
       balls.forEach((ball, index) => {
         if (ball.position.y > height - 60 && Math.abs(ball.velocity.y) < 1) {
-          const bucket = Math.floor(ball.position.x / bucketWidth)
+          let bucket = -1
+          for (let i = 0; i < bounds.length - 1; i++) {
+            if (ball.position.x >= bounds[i] && ball.position.x < bounds[i + 1]) {
+              bucket = i
+              break
+            }
+          }
           if (bucket >= 0 && bucket < bucketCounts.length) {
             bucketCounts[bucket] += 1
             Composite.remove(engine.world, ball)
@@ -174,14 +262,17 @@ export function Plinko({ initialConfig }: PlinkoProps) {
         <div className="space-y-4 p-2 border rounded-md">
           <fieldset className="space-y-2">
             <legend className="font-semibold">Balls</legend>
-            <div className="grid grid-cols-2 gap-2 items-center">
+            <div className="flex items-center gap-2">
+              <label className="w-32">Count</label>
               <RangeSlider
+                className="flex-1"
                 value={config.ballCount}
                 onValueChange={v => updateConfig('ballCount', v)}
                 min={1}
                 max={50}
               />
               <Input
+                className="w-20"
                 type="number"
                 value={config.ballCount}
                 onChange={e => updateConfig('ballCount', Number(e.target.value))}
@@ -189,17 +280,161 @@ export function Plinko({ initialConfig }: PlinkoProps) {
                 max={50}
               />
             </div>
+            <div className="flex items-center gap-2">
+              <label className="w-32">Restitution</label>
+              <RangeSlider
+                className="flex-1"
+                value={config.ballRestitution}
+                onValueChange={v => updateConfig('ballRestitution', v)}
+                min={0}
+                max={1}
+                step={0.05}
+              />
+              <Input
+                className="w-20"
+                type="number"
+                value={config.ballRestitution}
+                onChange={e => updateConfig('ballRestitution', Number(e.target.value))}
+                min={0}
+                max={1}
+                step={0.05}
+              />
+            </div>
+            <div className="flex items-center gap-2">
+              <label className="w-32">Friction</label>
+              <RangeSlider
+                className="flex-1"
+                value={config.ballFriction}
+                onValueChange={v => updateConfig('ballFriction', v)}
+                min={0}
+                max={1}
+                step={0.01}
+              />
+              <Input
+                className="w-20"
+                type="number"
+                value={config.ballFriction}
+                onChange={e => updateConfig('ballFriction', Number(e.target.value))}
+                min={0}
+                max={1}
+                step={0.01}
+              />
+            </div>
+            <div className="flex items-center gap-2">
+              <label className="w-32">Shape</label>
+              <Select
+                className="w-20"
+                value={config.ballShape}
+                onChange={e => updateConfig('ballShape', e.target.value as PlinkoConfig['ballShape'])}
+              >
+                <option value="ball">Ball</option>
+                <option value="square">Square</option>
+                <option value="triangle">Triangle</option>
+              </Select>
+            </div>
+            <div className="flex items-center gap-2">
+              <label className="w-32">Drop Location</label>
+              <Select
+                className="w-20"
+                value={config.dropLocation}
+                onChange={e => updateConfig('dropLocation', e.target.value as PlinkoConfig['dropLocation'])}
+              >
+                <option value="random">Random</option>
+                <option value="zigzag">Zig-Zag</option>
+                <option value="center">Center</option>
+              </Select>
+            </div>
+          </fieldset>
+          <fieldset className="space-y-2">
+            <legend className="font-semibold">Pins</legend>
+            <div className="flex items-center gap-2">
+              <label className="w-32">Rows</label>
+              <Input
+                className="w-20"
+                type="number"
+                value={config.pinRows}
+                onChange={e => updateConfig('pinRows', Number(e.target.value))}
+                min={1}
+                max={20}
+              />
+            </div>
+            <div className="flex items-center gap-2">
+              <label className="w-32">Columns</label>
+              <Input
+                className="w-20"
+                type="number"
+                value={config.pinColumns}
+                onChange={e => updateConfig('pinColumns', Number(e.target.value))}
+                min={1}
+                max={20}
+              />
+            </div>
+            <div className="flex items-center gap-2">
+              <label className="w-32">Restitution</label>
+              <RangeSlider
+                className="flex-1"
+                value={config.pinRestitution}
+                onValueChange={v => updateConfig('pinRestitution', v)}
+                min={0}
+                max={1}
+                step={0.05}
+              />
+              <Input
+                className="w-20"
+                type="number"
+                value={config.pinRestitution}
+                onChange={e => updateConfig('pinRestitution', Number(e.target.value))}
+                min={0}
+                max={1}
+                step={0.05}
+              />
+            </div>
+            <div className="flex items-center gap-2">
+              <label className="w-32">Friction</label>
+              <RangeSlider
+                className="flex-1"
+                value={config.pinFriction}
+                onValueChange={v => updateConfig('pinFriction', v)}
+                min={0}
+                max={1}
+                step={0.01}
+              />
+              <Input
+                className="w-20"
+                type="number"
+                value={config.pinFriction}
+                onChange={e => updateConfig('pinFriction', Number(e.target.value))}
+                min={0}
+                max={1}
+                step={0.01}
+              />
+            </div>
+            <div className="flex items-center gap-2">
+              <label className="w-32">Shape</label>
+              <Select
+                className="w-20"
+                value={config.pinShape}
+                onChange={e => updateConfig('pinShape', e.target.value as PlinkoConfig['pinShape'])}
+              >
+                <option value="ball">Ball</option>
+                <option value="square">Square</option>
+                <option value="triangle">Triangle</option>
+              </Select>
+            </div>
           </fieldset>
           <fieldset className="space-y-2">
             <legend className="font-semibold">Board</legend>
-            <div className="grid grid-cols-2 gap-2 items-center">
+            <div className="flex items-center gap-2">
+              <label className="w-32">Width</label>
               <RangeSlider
+                className="flex-1"
                 value={config.width}
                 onValueChange={v => updateConfig('width', v)}
                 min={300}
                 max={1000}
               />
               <Input
+                className="w-20"
                 type="number"
                 value={config.width}
                 onChange={e => updateConfig('width', Number(e.target.value))}
@@ -207,14 +442,17 @@ export function Plinko({ initialConfig }: PlinkoProps) {
                 max={1000}
               />
             </div>
-            <div className="grid grid-cols-2 gap-2 items-center">
+            <div className="flex items-center gap-2">
+              <label className="w-32">Height</label>
               <RangeSlider
+                className="flex-1"
                 value={config.height}
                 onValueChange={v => updateConfig('height', v)}
                 min={300}
                 max={800}
               />
               <Input
+                className="w-20"
                 type="number"
                 value={config.height}
                 onChange={e => updateConfig('height', Number(e.target.value))}
@@ -224,15 +462,51 @@ export function Plinko({ initialConfig }: PlinkoProps) {
             </div>
           </fieldset>
           <fieldset className="space-y-2">
-            <legend className="font-semibold">Win</legend>
-            <div className="grid grid-cols-2 gap-2 items-center">
+            <legend className="font-semibold">Buckets</legend>
+            <div className="flex items-center gap-2">
+              <label className="w-32">Count</label>
               <RangeSlider
+                className="flex-1"
+                value={config.bucketCount}
+                onValueChange={v => updateConfig('bucketCount', v)}
+                min={2}
+                max={10}
+              />
+              <Input
+                className="w-20"
+                type="number"
+                value={config.bucketCount}
+                onChange={e => updateConfig('bucketCount', Number(e.target.value))}
+                min={2}
+                max={10}
+              />
+            </div>
+            <div className="flex items-center gap-2">
+              <label className="w-32">Distribution</label>
+              <Select
+                className="w-20"
+                value={config.bucketDistribution}
+                onChange={e => updateConfig('bucketDistribution', e.target.value as PlinkoConfig['bucketDistribution'])}
+              >
+                <option value="even">Even</option>
+                <option value="middle">Middle-Weighted</option>
+                <option value="edge">Edge-Weighted</option>
+              </Select>
+            </div>
+          </fieldset>
+          <fieldset className="space-y-2">
+            <legend className="font-semibold">Win</legend>
+            <div className="flex items-center gap-2">
+              <label className="w-32">Per Bucket</label>
+              <RangeSlider
+                className="flex-1"
                 value={config.winCount}
                 onValueChange={v => updateConfig('winCount', v)}
                 min={1}
                 max={config.ballCount}
               />
               <Input
+                className="w-20"
                 type="number"
                 value={config.winCount}
                 onChange={e => updateConfig('winCount', Number(e.target.value))}

--- a/src/components/game/Plinko.tsx
+++ b/src/components/game/Plinko.tsx
@@ -82,6 +82,7 @@ export function Plinko({ initialConfig }: PlinkoProps) {
   const [started, setStarted] = useState(false)
   const [config, setConfig] = useState<PlinkoConfig>(initialConfig ?? defaultConfig)
   const [showConfig, setShowConfig] = useState(false)
+  const [boardKey, setBoardKey] = useState(0)
   const bucketBoundsRef = useRef<number[]>([])
   const preserveBallsRef = useRef(false)
   const restartRef = useRef(false)
@@ -95,6 +96,7 @@ export function Plinko({ initialConfig }: PlinkoProps) {
     preserveBallsRef.current = false
     if (resetBoard) {
       setConfig(prev => ({ ...prev }))
+      setBoardKey(k => k + 1)
     }
     setStarted(true)
   }
@@ -104,6 +106,7 @@ export function Plinko({ initialConfig }: PlinkoProps) {
     value: PlinkoConfig[K]
   ) => {
     setConfig(prev => ({ ...prev, [key]: value }))
+    setBoardKey(k => k + 1)
     if (started) {
       restartRef.current = true
       stopGame(false)
@@ -340,6 +343,7 @@ export function Plinko({ initialConfig }: PlinkoProps) {
   return (
     <div className="space-y-2">
       <div
+        key={boardKey}
         className="border"
         ref={canvasRef}
         style={{ width: config.width, height: config.height }}

--- a/src/components/game/Plinko.tsx
+++ b/src/components/game/Plinko.tsx
@@ -1,0 +1,210 @@
+"use client"
+
+import React, { useRef, useState, useEffect } from "react"
+import Matter, { Engine, Render, Runner, Bodies, Composite, Events } from "matter-js"
+import { Button } from "@/components/ui/button"
+import { Input, RangeSlider } from "@/components/ui"
+
+export interface PlinkoConfig {
+  ballCount: number
+  ballRadius: number
+  ballRestitution: number
+  ballFriction: number
+  pinRadius: number
+  pinRows: number
+  pinColumns: number
+  wallThickness: number
+  bucketCount: number
+  winCount: number
+  autoStart: boolean
+}
+
+export interface PlinkoProps {
+  /** starting configuration */
+  initialConfig?: PlinkoConfig
+}
+
+const defaultConfig: PlinkoConfig = {
+  ballCount: 10,
+  ballRadius: 8,
+  ballRestitution: 0.9,
+  ballFriction: 0.005,
+  pinRadius: 3,
+  pinRows: 10,
+  pinColumns: 8,
+  wallThickness: 10,
+  bucketCount: 6,
+  winCount: 3,
+  autoStart: false
+}
+
+export function Plinko({ initialConfig }: PlinkoProps) {
+  const canvasRef = useRef<HTMLDivElement>(null)
+  const [engine] = useState(() => Engine.create())
+  const [runner] = useState(() => Runner.create())
+  const [started, setStarted] = useState(false)
+  const [config, setConfig] = useState<PlinkoConfig>(initialConfig ?? defaultConfig)
+  const [showConfig, setShowConfig] = useState(false)
+  
+  const updateConfig = (key: keyof PlinkoConfig, value: number | boolean) => {
+    setConfig(prev => ({ ...prev, [key]: value }))
+  }
+
+  useEffect(() => {
+    if (config.autoStart && !started) {
+      setStarted(true)
+    }
+  }, [config.autoStart, started])
+
+  useEffect(() => {
+    if (started && canvasRef.current != null) {
+      const width = canvasRef.current.clientWidth
+      const height = 500
+      const render = Render.create({
+        element: canvasRef.current,
+        engine,
+        options: { width, height, wireframes: false, background: "#f8fafc" }
+      })
+
+      const walls = [
+        Bodies.rectangle(width / 2, -25, width, 50, { isStatic: true }),
+        Bodies.rectangle(width / 2, height + 25, width, 50, { isStatic: true }),
+        Bodies.rectangle(-25, height / 2, 50, height, { isStatic: true }),
+        Bodies.rectangle(width + 25, height / 2, 50, height, { isStatic: true })
+      ]
+
+      Composite.add(engine.world, walls)
+
+      // pins
+      const xSpacing = width / config.pinColumns
+      const ySpacing = (height - 100) / config.pinRows
+      const pins: Matter.Body[] = []
+      for (let row = 0; row < config.pinRows; row++) {
+        for (let col = 0; col < config.pinColumns; col++) {
+          const x = xSpacing / 2 + col * xSpacing + (row % 2 === 0 ? xSpacing / 2 : 0)
+          const y = 50 + row * ySpacing
+          pins.push(Bodies.circle(x, y, config.pinRadius, { isStatic: true }))
+        }
+      }
+      Composite.add(engine.world, pins)
+
+      // buckets
+      const bucketWidth = width / config.bucketCount
+      for (let i = 0; i <= config.bucketCount; i++) {
+        const x = i * bucketWidth
+        Composite.add(engine.world, [
+          Bodies.rectangle(x, height - 50, config.wallThickness, 100, { isStatic: true })
+        ])
+      }
+
+      Render.run(render)
+      Runner.run(runner, engine)
+
+      let dropped = 0
+      const balls: Matter.Body[] = []
+      const bucketCounts = new Array(config.bucketCount).fill(0)
+      const dropInterval = setInterval(() => {
+        if (dropped >= config.ballCount) {
+          clearInterval(dropInterval)
+          return
+        }
+        const ball = Bodies.circle(width / 2, 0, config.ballRadius, {
+          restitution: config.ballRestitution,
+          friction: config.ballFriction
+        })
+        balls.push(ball)
+        Composite.add(engine.world, ball)
+        dropped += 1
+      }, 500)
+
+      const afterUpdate = () => {
+        balls.forEach((ball, index) => {
+          if (ball.position.y > height - 60 && Math.abs(ball.velocity.y) < 1) {
+            const bucket = Math.floor(ball.position.x / bucketWidth)
+            if (bucket >= 0 && bucket < bucketCounts.length) {
+              bucketCounts[bucket] += 1
+              Composite.remove(engine.world, ball)
+              balls.splice(index, 1)
+              if (bucketCounts[bucket] >= config.winCount) {
+                setStarted(false)
+                clearInterval(dropInterval)
+              }
+            }
+          }
+        })
+      }
+      Events.on(engine, "afterUpdate", afterUpdate)
+
+      return () => {
+        clearInterval(dropInterval)
+        Events.off(engine, "afterUpdate", afterUpdate)
+        Render.stop(render)
+        Runner.stop(runner)
+        Composite.clear(engine.world, false)
+        if (render.canvas.parentNode != null) {
+          render.canvas.parentNode.removeChild(render.canvas)
+        }
+      }
+    }
+  }, [started, config, engine, runner])
+
+  return (
+    <div className="space-y-2">
+      <div className="w-full border" ref={canvasRef} />
+      <div className="flex gap-2">
+        <Button onClick={() => setStarted(true)}>Start</Button>
+        <Button variant="outline" onClick={() => setShowConfig(v => !v)}>
+          Config
+        </Button>
+      </div>
+      {showConfig && (
+        <div className="space-y-4 p-2 border rounded-md">
+          <fieldset className="space-y-2">
+            <legend className="font-semibold">Balls</legend>
+            <div className="grid grid-cols-2 gap-2 items-center">
+              <RangeSlider
+                value={config.ballCount}
+                onValueChange={v => updateConfig('ballCount', v)}
+                min={1}
+                max={50}
+              />
+              <Input
+                type="number"
+                value={config.ballCount}
+                onChange={e => updateConfig('ballCount', Number(e.target.value))}
+                min={1}
+                max={50}
+              />
+            </div>
+          </fieldset>
+          <fieldset className="space-y-2">
+            <legend className="font-semibold">Win</legend>
+            <div className="grid grid-cols-2 gap-2 items-center">
+              <RangeSlider
+                value={config.winCount}
+                onValueChange={v => updateConfig('winCount', v)}
+                min={1}
+                max={config.ballCount}
+              />
+              <Input
+                type="number"
+                value={config.winCount}
+                onChange={e => updateConfig('winCount', Number(e.target.value))}
+                min={1}
+                max={config.ballCount}
+              />
+            </div>
+            <div className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={config.autoStart}
+                onChange={e => updateConfig('autoStart', e.target.checked)}
+              />
+              <span>Auto Start</span>
+            </div>
+          </fieldset>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+

--- a/src/components/ui/RangeSlider.tsx
+++ b/src/components/ui/RangeSlider.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+export interface RangeSliderProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  value: number
+  onValueChange: (value: number) => void
+  min: number
+  max: number
+}
+
+export function RangeSlider({ className, value, onValueChange, min, max, ...props }: RangeSliderProps) {
+  return (
+    <input
+      type="range"
+      className={cn("w-full h-2", className)}
+      value={value}
+      onChange={(e) => onValueChange(Number(e.target.value))}
+      min={min}
+      max={max}
+      {...props}
+    />
+  )
+}
+

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -1,0 +1,20 @@
+"use client"
+
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+export type SelectProps = React.SelectHTMLAttributes<HTMLSelectElement>
+
+export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
+  ({ className, ...props }, ref) => (
+    <select
+      ref={ref}
+      className={cn(
+        "flex h-10 rounded-md border border-input bg-background px-3 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+)
+Select.displayName = "Select"

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -3,4 +3,5 @@ export * from "./table"
 export * from "./Loader"
 export * from "./Input"
 export * from "./RangeSlider"
+export * from "./Select"
 

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,0 +1,6 @@
+export * from "./button"
+export * from "./table"
+export * from "./Loader"
+export * from "./Input"
+export * from "./RangeSlider"
+

--- a/src/hooks/useAsyncEffect.ts
+++ b/src/hooks/useAsyncEffect.ts
@@ -77,11 +77,15 @@ function wakeup(state: State, tag?: string): void {
       .then(cleanup => {
         state.lastCleanup = cleanup ?? undefined
         state.running = false
+        // // Use setTimeout to prevent stack overflow from recursive calls
+        // setTimeout(() => wakeup(state, tag), 0)
         wakeup(state, tag)
       })
       .catch(error => {
         console.error(error, { tag })
         state.running = false
+        // // Use setTimeout to prevent stack overflow from recursive calls
+        // setTimeout(() => wakeup(state, tag), 0)
         wakeup(state, tag)
       })
   }


### PR DESCRIPTION
## Summary
- add a simple Plinko game component using matter.js
- expose default configuration for balls, pins, and board
- include a configuration menu with sliders and inputs
- create input and range slider shadcn-style components
- export new UI components
- create `/plinko` page to demonstrate the game

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685b50ccd71083318411e14636409533